### PR TITLE
Add service account to config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "firebase-functions",
+  "name": "@backtowork-app/firebase-functions",
   "version": "3.11.0",
   "description": "Firebase SDK for Cloud Functions",
   "keywords": [
@@ -8,13 +8,14 @@
     "google",
     "cloud"
   ],
-  "homepage": "https://github.com/firebase/firebase-functions#readme",
+  "homepage": "https://github.com/@backtowork-app/firebase-functions#readme",
   "bugs": {
-    "url": "https://github.com/firebase/firebase-functions/issues"
+    "url": "https://github.com/@backtowork-app/firebase-functions/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/firebase/firebase-functions.git"
+    "url": "https://github.com/backtowork-app/firebase-functions.git",
+    "directory": "packages/firebase-functions"
   },
   "license": "MIT",
   "author": "Firebase Team",
@@ -24,7 +25,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
+    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "apidocs": "node docgen/generate-docs.js",

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -249,6 +249,6 @@ describe('FunctionBuilder', () => {
       .auth.user()
       .onCreate((user) => user);
 
-    expect(fn.__trigger.vpcConnector).to.equal(serviceAccountEmail);
+    expect(fn.__trigger.serviceAccountEmail).to.equal(serviceAccountEmail);
   });
 });

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -238,4 +238,17 @@ describe('FunctionBuilder', () => {
       )}`
     );
   });
+
+  it('should allow a serviceAccountEmail to be set', () => {
+    const serviceAccountEmail =
+      'test-service-account@test.iam.gserviceaccount.com';
+    const fn = functions
+      .runWith({
+        serviceAccountEmail,
+      })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.vpcConnector).to.equal(serviceAccountEmail);
+  });
 });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -272,6 +272,7 @@ export interface TriggerAnnotated {
     timeout?: string;
     vpcConnector?: string;
     vpcConnectorEgressSettings?: string;
+    serviceAccountEmail?: string;
   };
 }
 
@@ -523,6 +524,10 @@ export function optionsToTrigger(options: DeploymentOptions) {
 
   if (options.vpcConnectorEgressSettings) {
     trigger.vpcConnectorEgressSettings = options.vpcConnectorEgressSettings;
+  }
+
+  if(options.serviceAccountEmail){
+    trigger.serviceAccountEmail = options.serviceAccountEmail;
   }
 
   return trigger;

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -142,6 +142,7 @@ export function region(
  * 4. vpcConnector: id of a VPC connector in same project and region
  * 5. vpcConnectorEgressSettings: when a vpcConnector is set, control which
  *    egress traffic is sent through the vpcConnector.
+ * 6. serviceAccountEmail: email address of specific service account
  *
  * Value must not be null.
  */

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -110,6 +110,11 @@ export interface RuntimeOptions {
    * Egress settings for VPC connector
    */
   vpcConnectorEgressSettings?: typeof VPC_EGRESS_SETTINGS_OPTIONS[number];
+
+  /**
+   * Set specific service account
+   */
+  serviceAccountEmail?: string;
 }
 
 export interface DeploymentOptions extends RuntimeOptions {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description
Working with firebase functions in a huge project we need to set specific service account for most of the functions. Based on that requirement I've added `serviceAccountEmail` property to `RuntimeOptions`.

### Code sample

```js
const fn = functions
      .runWith({
        serviceAccountEmail: 'test-service-account@test.iam.gserviceaccount.com'
      })
      .auth.user()
      .onCreate((user) => user);
```